### PR TITLE
Install instructions for Arch / Manjaro

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,33 @@ which looks like
 * python3-xlib
 
 ## Installation on Ubuntu
+
+Go to a directory you want to store snaptile:
 ```bash
-$ sudo apt-get install git python3-gi python3-xlib
-$ cd <place-you-want-to-store-snaptile>
-$ git clone https://github.com/jakebian/snaptile.git
-$ cd snaptile && ./snaptile.py
+cd <place-you-want-to-store-snaptile>
 ```
+
+Install and run:
+```bash
+sudo apt-get install git python3-gi python3-xlib
+git clone https://github.com/jakebian/snaptile.git
+cd snaptile && ./snaptile.py
+```
+
+## Instalation on Arch / Manjaro
+Go to a directory you want to store snaptile:
+```bash
+cd <place-you-want-to-store-snaptile>
+```
+
+Install and run:
+```bash
+sudo pacman -S git python-gobject python-xlib
+git clone https://github.com/jakebian/snaptile.git
+cd snaptile && ./snaptile.py
+```
+
+## Start at boot
 
 To start at boot, just add a script to *Startup Applications* invoking the python script
 ```bash


### PR DESCRIPTION
Nice little tool you have here.

I've tried it on a Manjaro XFCE4 vm I had around. Seems to work well, apart for some <kbd>Ctrl</kbd><kbd>Alt</kbd><kbd>Shift</kbd> key combos being already in use.

I've documented the dependency names as they are found with pacman (package manager for arch based linuxes).