### PR TITLE
Lots of changes (see description)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The grid system divides your screen into 12 sections
 | <kbd>A</kbd>| <kbd>S</kbd>| <kbd>D</kbd>| <kbd>F</kbd>|
 | <kbd>Z</kbd>| <kbd>X</kbd>| <kbd>C</kbd>| <kbd>V</kbd>|
 
+or, in dual screen mode (`-d` switch), into 12 sections each, with extended keybindings for the second screen:
+
+| <kbd>T</kbd>| <kbd>Y</kbd>| <kbd>U</kbd>| <kbd>I</kbd>|
+|--|--|--|--|
+| <kbd>G</kbd>| <kbd>H</kbd>| <kbd>J</kbd>| <kbd>K</kbd>|
+| <kbd>B</kbd>| <kbd>N</kbd>| <kbd>M</kbd>| <kbd>,</kbd>|
+
 You can snap your window to any rectangle, of any arbitrary size, on this grid by specifying 2 corners. For example:
 
 <kbd>ctl</kbd> + <kbd>alt</kbd> + <kbd>E</kbd> + <kbd>D</kbd>
@@ -42,6 +49,14 @@ The two keys only needs to "span" a rectangle. For example:
 which looks like
 
 ![screenshot from 2017-06-07 22-55-56](https://user-images.githubusercontent.com/5866348/26910417-b381baca-4bd4-11e7-9ff7-fff9262743e8.png)
+
+### Fill
+With the `-f` switch, filling is activated. On double press of any of the shortcuts, snaptile will try to find as many sections
+around the specified one as possible without intersecting with other windows, and fill the largest match. This will still align to the 4x3 grid.
+Windows which obstruct the initial section are excluded from intersection, so they might be partially or even completely occluded.
+
+For example, if there is a window between tiles <kbd>Q</kbd> and <kbd>S</kbd>, double pressing <kbd>ctl</kbd> + <kbd>alt</kbd> + <kbd>X</kbd>
+will have the same outcome as <kbd>Z</kbd> and <kbd>V</kbd>. Double <kbd>C</kbd>, on the other hand, will result in <kbd>E</kbd> and <kbd>V</kbd>.
 
 
 ## Requirements

--- a/geom_utils.py
+++ b/geom_utils.py
@@ -1,0 +1,28 @@
+def grid_to_coords(pos, monitor):
+    geom = monitor.get_geometry()
+    x = geom.x + (pos[1] % 4) * geom.width // 4
+    y = geom.y + (pos[0] % 3) * geom.height // 3
+    return (x, y, x + geom.width // 4, y + geom.height // 3)
+
+
+def grid_to_xywh(pos, monitor):
+    coords = grid_to_coords(pos, monitor)
+    return (
+        coords[0],
+        coords[1],
+        coords[2] - coords[0],
+        coords[3] - coords[1],
+    )
+
+
+def geom_to_tuple(geom):
+    return (geom.x, geom.y, geom.width, geom.height)
+
+
+def overlaps(geom1, geom2):
+    return not (
+        geom1[0] >= geom2[0] + geom2[2] or
+        geom1[0] + geom1[2] <= geom2[0] or
+        geom1[1] >= geom2[1] + geom2[3] or
+        geom1[1] + geom1[3] <= geom2[1]
+    )

--- a/snaptile.py
+++ b/snaptile.py
@@ -97,7 +97,7 @@ def global_inital_states():
         get_posmap(keymap, displ)
     )
 
-global disp, root, lastkey_state, posmap;
+global disp, root, lastkey_state, posmap, isDualMonitor;
 
 
 def run():
@@ -105,6 +105,9 @@ def run():
 
     opts, args = getopt.getopt(sys.argv[1:], "hdWk:")
     keyboardLayout = autodetectKeyboard()
+
+    global isDualMonitor
+
     isDualMonitor = False
     
     for opt in opts:
@@ -175,7 +178,8 @@ def checkevt(_, __, handle=None):
 def handleevt(startkey, endkey):
     position(
         posmap[startkey],
-        posmap[endkey]
+        posmap[endkey],
+        isDualMonitor,
     )
 
 if __name__ == '__main__':

--- a/snaptile.py
+++ b/snaptile.py
@@ -97,7 +97,8 @@ def global_inital_states():
         rt,
         {
             'code': 0,
-            'pressed': False
+            'pressed': False,
+            'window': None,
         },
         get_posmap(keymap, displ)
     )
@@ -116,7 +117,7 @@ def run():
     isDualMonitor = False
 
     fillEnabled = False
-    
+
     for opt in opts:
         if opt[0] == '-h':
             print ('Snaptile.py')
@@ -175,21 +176,30 @@ def checkevt(_, __, handle=None):
             # prevent loosing double press release events
             root.grab_keyboard(1, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
 
+            win = None
             if not lastkey_state['pressed']:
                 if fillEnabled and \
                    lastkey_state['code'] == event.detail and \
                    time.time() - lastkey_state['time'] < fill_delay:
-                    handle_fill(event.detail)
+                    win = handle_fill(
+                        event.detail,
+                        lastkey_state['window'],
+                    )
                 else:
-                    handleevt(event.detail, event.detail)
+                    win = handleevt(event.detail, event.detail)
 
             else:
-                handleevt(lastkey_state['code'], event.detail)
+                win = handleevt(
+                    lastkey_state['code'],
+                    event.detail,
+                    lastkey_state['window'],
+                )
 
             lastkey_state = {
                 'code': event.detail,
                 'pressed': True,
                 'time': time.time(),
+                'window': win,
             }
 
         if event.type == X.KeyRelease:
@@ -209,15 +219,16 @@ def checkevt(_, __, handle=None):
 
     return True
 
-def handleevt(startkey, endkey):
-    position(
+def handleevt(startkey, endkey, window=None):
+    return position(
         posmap[startkey],
         posmap[endkey],
         isDualMonitor,
+        window,
     )
 
-def handle_fill(key):
-    fill(posmap[key], isDualMonitor)
+def handle_fill(key, window=None):
+    return fill(posmap[key], isDualMonitor, window)
 
 if __name__ == '__main__':
     run()

--- a/snaptile.py
+++ b/snaptile.py
@@ -144,6 +144,7 @@ def run():
     GObject.io_add_watch(root.display, GObject.IO_IN, checkevt)
     print('Snaptile running. Press CTRL+C to quit.')
     signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)
     Gtk.main()
 
 def checkevt(_, __, handle=None):

--- a/snaptile.py
+++ b/snaptile.py
@@ -9,7 +9,7 @@ from Xlib import display, X
 
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, GObject
+from gi.repository import Gtk, GLib
 from window import position
 from keyutil import get_posmap, initkeys
 
@@ -141,7 +141,7 @@ def run():
     initkeys(keymap, disp, root, mask)
     for _ in range(0, root.display.pending_events()):
         root.display.next_event()
-    GObject.io_add_watch(root.display, GObject.IO_IN, checkevt)
+    GLib.io_add_watch(root.display, GLib.IO_IN, checkevt)
     print('Snaptile running. Press CTRL+C to quit.')
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     signal.signal(signal.SIGTERM, signal.SIG_DFL)

--- a/window.py
+++ b/window.py
@@ -1,5 +1,6 @@
 from gi.repository import Gdk
 from itertools import product
+from geom_utils import grid_to_coords, grid_to_xywh, geom_to_tuple, overlaps
 
 def position(startpos, endpos, dualMonitor):
     window, screen = active_window()
@@ -102,37 +103,6 @@ def fill(pos, dualMonitor):
     window.unmaximize()
     window.set_shadow_width(0, 0, 0, 0)
     window.move_resize(*best_pos)
-
-
-# TODO move to geom_utils
-def grid_to_coords(pos, monitor):
-    geom = monitor.get_geometry()
-    x = geom.x + (pos[1] % 4) * geom.width // 4
-    y = geom.y + (pos[0] % 3) * geom.height // 3
-    return (x, y, x + geom.width // 4, y + geom.height // 3)
-
-
-def grid_to_xywh(pos, monitor):
-    coords = grid_to_coords(pos, monitor)
-    return (
-        coords[0],
-        coords[1],
-        coords[2] - coords[0],
-        coords[3] - coords[1],
-    )
-
-
-def geom_to_tuple(geom):
-    return (geom.x, geom.y, geom.width, geom.height)
-
-
-def overlaps(geom1, geom2):
-    return not (
-        geom1[0] >= geom2[0] + geom2[2] or
-        geom1[0] + geom1[2] <= geom2[0] or
-        geom1[1] >= geom2[1] + geom2[3] or
-        geom1[1] + geom1[3] <= geom2[1]
-    )
 
 
 def active_window():

--- a/window.py
+++ b/window.py
@@ -1,6 +1,6 @@
 from gi.repository import Gdk
 
-def position(startpos, endpos):
+def position(startpos, endpos, dualMonitor):
     window, screen = active_window()
     window.unmaximize()
     window.set_shadow_width(0, 0, 0, 0)
@@ -19,7 +19,10 @@ def position(startpos, endpos):
     )
 
 
-    multiscreen_offset = get_multi_screen_offset(screen, window)
+    if dualMonitor:
+        multiscreen_offset = 0
+    else:
+        multiscreen_offset = get_multi_screen_offset(screen, window)
 
     window.move_resize(
         pos[1] * w + multiscreen_offset,

--- a/window.py
+++ b/window.py
@@ -2,6 +2,8 @@ from gi.repository import Gdk
 
 def position(startpos, endpos, dualMonitor):
     window, screen = active_window()
+    if window is None:
+        return
     window.unmaximize()
     window.set_shadow_width(0, 0, 0, 0)
     workarea = screen.get_monitor_workarea(screen.get_monitor_at_window(window))
@@ -45,7 +47,7 @@ def active_window():
     window = screen.get_active_window()
 
     if no_window(screen, window):
-        return None
+        return None, None
 
     return (window, screen)
 

--- a/window.py
+++ b/window.py
@@ -6,41 +6,53 @@ def position(startpos, endpos, dualMonitor):
         return
     window.unmaximize()
     window.set_shadow_width(0, 0, 0, 0)
-    workarea = screen.get_monitor_workarea(screen.get_monitor_at_window(window))
+
     display = Gdk.Display.get_default()
+    if dualMonitor:
+        monitor = get_target_monitor(display, startpos[1])
+        workarea = monitor.get_workarea()
+        end_monitor = get_target_monitor(display, endpos[1])
+        end_workarea = end_monitor.get_workarea()
+    else:
+        monitor = screen.get_monitor_at_window(window)
+        workarea = screen.get_monitor_workarea(monitor)
+        # same screen -> same workarea on both corners
+        end_workarea = workarea
 
-    offx, offy = offsets(window)
     w, h = (workarea.width / 4, workarea.height / 3)
+    end_w, end_h = (end_workarea.width / 4, end_workarea.height / 3)
 
-    pos = (
-        min(startpos[0], endpos[0]),
-        min(startpos[1], endpos[1])
+    # each contain top left and bottom right position of the respective cell
+    first_corner = (
+        (startpos[1] % 4) * w + workarea.x,
+        startpos[0] * h + workarea.y,
+        (startpos[1] % 4 + 1) * w + workarea.x,
+        (startpos[0] + 1) * h + workarea.y,
     )
+    second_corner = (
+        (endpos[1] % 4) * end_w + end_workarea.x,
+        endpos[0] * end_h + end_workarea.y,
+        (endpos[1] % 4 + 1) * end_w + end_workarea.x,
+        (endpos[0] + 1) * end_h + end_workarea.y,
+    )
+
+    top_left, bottom_right = (
+        # use top left corner of cells (0 & 1)
+        (min(first_corner[0], second_corner[0]), min(first_corner[1], second_corner[1])),
+        # use bottom right corner of cells (2 & 3)
+        (max(first_corner[2], second_corner[2]), max(first_corner[3], second_corner[3])),
+    )
+
     dims = (
-        max(abs(endpos[0] - startpos[0]) + 1, 1),
-        max(abs(endpos[1] - startpos[1]) + 1, 1)
+        bottom_right[0] - top_left[0],
+        bottom_right[1] - top_left[1],
     )
-
-
-    if dualMonitor:
-        multiscreen_offset = 0
-    else:
-        multiscreen_offset = get_multi_screen_offset(screen, window)
-
-    if dualMonitor:
-        screen_y_offset = [
-            monitor_y_offset(display, min(startpos, endpos, key=lambda x: x[0]*10 + x[1])[1]),
-            monitor_y_offset(display, max(startpos, endpos, key=lambda x: x[0]*10 + x[1])[1]),
-        ]
-    else:
-        screen_y_offset = [0, 0]
 
     window.move_resize(
-        pos[1] * w + multiscreen_offset,
-        pos[0] * h + screen_y_offset[0],
-        w * dims[1] - (offx * 2),
-        h * dims[0]- (offx + offy) + screen_y_offset[1] - screen_y_offset[0]
+        *top_left,
+        *dims,
     )
+
 
 def active_window():
     screen = Gdk.Screen.get_default()
@@ -50,16 +62,6 @@ def active_window():
         return None, None
 
     return (window, screen)
-
-def get_multi_screen_offset(screen,window):
-    monitor = screen.get_monitor_at_window(window)
-    monitor_geometry = screen.get_monitor_geometry(monitor)
-    return monitor_geometry.x
-
-def offsets(window):
-    origin = window.get_origin()
-    root = window.get_root_origin()
-    return (origin.x - root.x, origin.y - root.y)
 
 
 def no_window(screen, window):
@@ -74,9 +76,10 @@ def no_window(screen, window):
     )
 
 
-def monitor_y_offset(display, x):
+def get_target_monitor(display, x):
+    # NOTE: only works for up to 2 monitors!!
     left_monitor = display.get_monitor_at_point(0, 0)
     right_monitor = display.get_monitor(1) \
                     if left_monitor == display.get_monitor(0) \
                        else display.get_monitor(0)
-    return [left_monitor, right_monitor][x // 4].get_workarea().y
+    return [left_monitor, right_monitor][x // 4]

--- a/window.py
+++ b/window.py
@@ -2,8 +2,11 @@ from gi.repository import Gdk
 from itertools import product
 from geom_utils import grid_to_coords, grid_to_xywh, geom_to_tuple, overlaps
 
-def position(startpos, endpos, dualMonitor):
-    window, screen = active_window()
+def position(startpos, endpos, dualMonitor, window=None):
+    if window is None:
+        window, screen = active_window()
+    else:
+        screen = Gdk.Screen.get_default()
     if window is None:
         return
     window.unmaximize()
@@ -54,12 +57,14 @@ def position(startpos, endpos, dualMonitor):
         *top_left,
         *dims,
     )
+    return window
 
 
-def fill(pos, dualMonitor):
+def fill(pos, dualMonitor, window=None):
     screen = Gdk.Screen.get_default()
     display = Gdk.Display.get_default()
-    window = screen.get_active_window()
+    if window is None:
+        window = screen.get_active_window()
     if dualMonitor:
         monitor = get_target_monitor(display, pos[1])
     else:
@@ -103,6 +108,7 @@ def fill(pos, dualMonitor):
     window.unmaximize()
     window.set_shadow_width(0, 0, 0, 0)
     window.move_resize(*best_pos)
+    return window
 
 
 def active_window():

--- a/window.py
+++ b/window.py
@@ -104,6 +104,7 @@ def fill(pos, dualMonitor):
     window.move_resize(*best_pos)
 
 
+# TODO move to geom_utils
 def grid_to_coords(pos, monitor):
     geom = monitor.get_geometry()
     x = geom.x + (pos[1] % 4) * geom.width // 4


### PR DESCRIPTION
This repository does not seem to be maintained any more. However, since I have been maintaining my own version of snaptile, I figured I'd open a PR for all my changes, in case anyone stumbles upon this and wants to use the fixes + features I have implemented, even if this PR is never merged.  
After this short disclaimer, now for the content of this PR:

* Fixed multiscreen mode (see #19, #20)
* Respond to SIGTERM, terminate application (-> to allow `kill <pid>`)
* Replaced deprecated GObject calls with newer methods
* Fixed a bug related to Xlib which ate key release events, leading to wrong placement after multiple tiling events
* Add fill mode (explained below)
* Prevent focus stealing for mouse hover activated windows (previously, if two tiles were selected, the window was moved after the first tile, and the window behind that one might have been activated if focus is mouse hover controlled)
* Code restructuring

## Fill mode
This mode can be enabled with the `-f ` switch; if enabled, double pressing the key for a single tile greedily fills as many tiles around this one as possible without overlapping other windows. Windows already intersecting the tile itself are ignored. For example, in the grid

| 1 | 2 | 3 | 4 |
|---|---|---|---|
| 5 | 6 | 7 | 8 |
| 9 | 10 | 11 | 12 |

if `6` contains another window and `9` is pressed twice, the window will span `9` to `12`. If 11 also contains another window, however, `1` to `9` will be chosen (since that spans 3 tiles, as opposed to only 2 for `9` to `10`).